### PR TITLE
Fix(Drawer): 修复显示关闭按钮的 IsShowCloseButton 属性支持

### DIFF
--- a/src/AtomUI.Controls/Drawer/Drawer.cs
+++ b/src/AtomUI.Controls/Drawer/Drawer.cs
@@ -377,6 +377,7 @@ public class Drawer : Control,
             BindUtils.RelayBind(this, PlacementProperty, _container, DrawerContainer.PlacementProperty);
             BindUtils.RelayBind(this, TitleProperty, _container, DrawerContainer.TitleProperty);
             BindUtils.RelayBind(this, IsShowMaskProperty, _container, DrawerContainer.IsShowMaskProperty);
+            BindUtils.RelayBind(this, IsShowCloseButtonProperty, _container, DrawerContainer.IsShowCloseButtonProperty);
             BindUtils.RelayBind(this, IsMotionEnabledProperty, _container, DrawerContainer.IsMotionEnabledProperty);
             BindUtils.RelayBind(this, CloseWhenClickOnMaskProperty, _container,
                 DrawerContainer.CloseWhenClickOnMaskProperty);

--- a/src/AtomUI.Controls/Drawer/Themes/DrawerContainerTheme.axaml
+++ b/src/AtomUI.Controls/Drawer/Themes/DrawerContainerTheme.axaml
@@ -24,6 +24,7 @@
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             IsMotionEnabled="{TemplateBinding IsMotionEnabled}"
+                            IsShowCloseButton="{TemplateBinding IsShowCloseButton}"
                             DialogSize="{TemplateBinding DialogSize}"/>
                     </atom:MotionActor>
                 </Panel>


### PR DESCRIPTION
<img width="1626" height="362" alt="image" src="https://github.com/user-attachments/assets/df119bd7-dd67-4de3-8a43-d1568f14d61a" />
<img width="617" height="226" alt="image" src="https://github.com/user-attachments/assets/b7bc9fe5-2690-4299-9e59-0a0e4fa7f36a" />
