### PR TITLE
fix(LineEdit): 修复输入框垂直尺寸问题

### DIFF
--- a/src/AtomUI.Controls/Input/Themes/LineEditTheme.axaml
+++ b/src/AtomUI.Controls/Input/Themes/LineEditTheme.axaml
@@ -12,6 +12,7 @@
         <ControlTemplate TargetType="atom:LineEdit">
             <atom:AddOnDecoratedBox
                 Name="{x:Static atom:TextBoxThemeConstants.DecoratedBoxPart}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}"
                 Focusable="False"
                 StyleVariant="{TemplateBinding StyleVariant}"
                 SizeType="{TemplateBinding SizeType}"


### PR DESCRIPTION
- 在LineEditTheme.axaml中为AddOnDecoratedBox添加VerticalAlignment绑定

Closes #42