### PR TITLE
Doc: 修正 README 体验所有控件 的指令

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,12 +222,12 @@ You can start using it in your own projects
 
 #### All Control Gallery
 
-You can experience all the controls by cloning the control gallery project to your local machine.
+You can launch the `./controlgallery/AtomUIGallery.Desktop/AtomUIGallery.Desktop.csproj` project in your local development environment to experience all AtomUI controls.
 
 ```bash
-git clone --recurse-submodules https://github.com/chinware/AtomUI.ControlGallery.git
-cd AtomUI.ControlGallery
-dotnet build
+git clone https://github.com/AtomUI/AtomUI.git
+dotnet restore
+dotnet run --project controlgallery/AtomUIGallery.Desktop/AtomUIGallery.Desktop.csproj -f net10.0
 ```
 
 <div style="height:50px"></div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -224,12 +224,12 @@ public partial class App : Application
 
 #### 体验所有控件
 
-您可以拉取控件库项目到本地来体验所有的 AtomUI 控件
+您可以启动 `./controlgallery/AtomUIGallery.Desktop/AtomUIGallery.Desktop.csproj` 项目在本机开发环境来体验所有的 AtomUI 控件
 
 ```bash
-git clone --recurse-submodules https://github.com/chinware/AtomUI.ControlGallery.git
-cd AtomUI.ControlGallery
-dotnet build
+git clone https://github.com/AtomUI/AtomUI.git
+dotnet restore
+dotnet run --project controlgallery/AtomUIGallery.Desktop/AtomUIGallery.Desktop.csproj -f net10.0
 ```
 
 <div style="height:50px"></div>


### PR DESCRIPTION
舊 Gallery 已經不存在，整合進 AtomUI/AtomUI 內了

舊有文件的命令也需要修正


從
```bash
git clone --recurse-submodules https://github.com/chinware/AtomUI.ControlGallery.git
cd AtomUI.ControlGallery
dotnet build
```

改為
```bash
git clone https://github.com/AtomUI/AtomUI.git
dotnet restore
dotnet run --project controlgallery/AtomUIGallery.Desktop/AtomUIGallery.Desktop.csproj -f net10.0
```