### PR TITLE
feat(image-previewer):  Supports mouse zoom and keyboard switching

### DIFF
--- a/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewBaseToolbar.cs
+++ b/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewBaseToolbar.cs
@@ -6,6 +6,22 @@ using Avalonia.Interactivity;
 
 namespace AtomUI.Desktop.Controls;
 
+internal enum ImagePreviewToolbarSource
+{
+    TitleBar,
+    Floating
+}
+
+internal class ImagePreviewToolbarRequestEventArgs : RoutedEventArgs
+{
+    public ImagePreviewToolbarSource ToolbarSource { get; }
+
+    public ImagePreviewToolbarRequestEventArgs(ImagePreviewToolbarSource source)
+    {
+        ToolbarSource = source;
+    }
+}
+
 internal class ImagePreviewBaseToolbar : TemplatedControl
 {
     public static readonly DirectProperty<ImagePreviewBaseToolbar, int> CurrentIndexProperty =
@@ -94,76 +110,76 @@ internal class ImagePreviewBaseToolbar : TemplatedControl
 
     #region 公共事件定义
 
-    public static RoutedEvent<RoutedEventArgs> HorizontalFlipRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(HorizontalFlipRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> HorizontalFlipRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(HorizontalFlipRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> VerticalFlipRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(VerticalFlipRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> VerticalFlipRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(VerticalFlipRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> ScaleUpRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(ScaleUpRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> ScaleUpRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(ScaleUpRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> ScaleDownRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(ScaleDownRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> ScaleDownRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(ScaleDownRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> PreviousRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(PreviousRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> PreviousRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(PreviousRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> NextRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(NextRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> NextRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(NextRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> RotateLeftRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(RotateLeftRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> RotateLeftRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(RotateLeftRequest), RoutingStrategies.Bubble);
     
-    public static RoutedEvent<RoutedEventArgs> RotateRightRequestEvent =
-        RoutedEvent.Register<ImagePreviewBaseToolbar, RoutedEventArgs>(nameof(RotateRightRequest), RoutingStrategies.Bubble);
+    public static RoutedEvent<ImagePreviewToolbarRequestEventArgs> RotateRightRequestEvent =
+        RoutedEvent.Register<ImagePreviewBaseToolbar, ImagePreviewToolbarRequestEventArgs>(nameof(RotateRightRequest), RoutingStrategies.Bubble);
     
     public static RoutedEvent<ImageFitToWindowEventArgs> FitToWindowRequestEvent =
         RoutedEvent.Register<ImagePreviewBaseToolbar, ImageFitToWindowEventArgs>(nameof(FitToWindowRequest), RoutingStrategies.Bubble);
     
-    public event EventHandler<RoutedEventArgs>? HorizontalFlipRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? HorizontalFlipRequest
     {
         add => AddHandler(HorizontalFlipRequestEvent, value);
         remove => RemoveHandler(HorizontalFlipRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? VerticalFlipRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? VerticalFlipRequest
     {
         add => AddHandler(VerticalFlipRequestEvent, value);
         remove => RemoveHandler(VerticalFlipRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? ScaleUpRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? ScaleUpRequest
     {
         add => AddHandler(ScaleUpRequestEvent, value);
         remove => RemoveHandler(ScaleUpRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? ScaleDownRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? ScaleDownRequest
     {
         add => AddHandler(ScaleDownRequestEvent, value);
         remove => RemoveHandler(ScaleDownRequestEvent, value);
     }
     
-    public event EventHandler<RoutedEventArgs>? PreviousRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? PreviousRequest
     {
         add => AddHandler(PreviousRequestEvent, value);
         remove => RemoveHandler(PreviousRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? NextRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? NextRequest
     {
         add => AddHandler(NextRequestEvent, value);
         remove => RemoveHandler(NextRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? RotateLeftRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? RotateLeftRequest
     {
         add => AddHandler(RotateLeftRequestEvent, value);
         remove => RemoveHandler(RotateLeftRequestEvent, value);
     }
 
-    public event EventHandler<RoutedEventArgs>? RotateRightRequest
+    public event EventHandler<ImagePreviewToolbarRequestEventArgs>? RotateRightRequest
     {
         add => AddHandler(RotateRightRequestEvent, value);
         remove => RemoveHandler(RotateRightRequestEvent, value);
@@ -185,6 +201,8 @@ internal class ImagePreviewBaseToolbar : TemplatedControl
     private IconButton? _rotateLeftButton;
     private IconButton? _rotateRightButton;
     private ToggleIconButton? _fitToWindowButton;
+
+    protected virtual ImagePreviewToolbarSource ToolbarSource => ImagePreviewToolbarSource.Floating;
     
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
@@ -251,35 +269,35 @@ internal class ImagePreviewBaseToolbar : TemplatedControl
     {
         if (sender == _horizontalFlipButton)
         {
-            RaiseEvent(new RoutedEventArgs(HorizontalFlipRequestEvent));
+            RaiseRequestEvent(HorizontalFlipRequestEvent);
         }
         else if (sender == _verticalFlipButton)
         {
-            RaiseEvent(new RoutedEventArgs(VerticalFlipRequestEvent));
+            RaiseRequestEvent(VerticalFlipRequestEvent);
         }
         else if (sender == _scaleUpButton)
         {
-            RaiseEvent(new RoutedEventArgs(ScaleUpRequestEvent));
+            RaiseRequestEvent(ScaleUpRequestEvent);
         }
         else if (sender == _scaleDownButton)
         {
-            RaiseEvent(new RoutedEventArgs(ScaleDownRequestEvent));
+            RaiseRequestEvent(ScaleDownRequestEvent);
         }
         else if (sender == _previousButton)
         {
-            RaiseEvent(new RoutedEventArgs(PreviousRequestEvent));
+            RaiseRequestEvent(PreviousRequestEvent);
         }
         else if (sender == _nextButton)
         {
-            RaiseEvent(new RoutedEventArgs(NextRequestEvent));
+            RaiseRequestEvent(NextRequestEvent);
         }
         else if (sender == _rotateLeftButton)
         {
-            RaiseEvent(new RoutedEventArgs(RotateLeftRequestEvent));
+            RaiseRequestEvent(RotateLeftRequestEvent);
         }
         else if (sender == _rotateRightButton)
         {
-            RaiseEvent(new RoutedEventArgs(RotateRightRequestEvent));
+            RaiseRequestEvent(RotateRightRequestEvent);
         }
         else if (sender == _fitToWindowButton)
         {
@@ -288,5 +306,13 @@ internal class ImagePreviewBaseToolbar : TemplatedControl
                 RoutedEvent = FitToWindowRequestEvent
             });
         }
+    }
+
+    private void RaiseRequestEvent(RoutedEvent<ImagePreviewToolbarRequestEventArgs> routedEvent)
+    {
+        RaiseEvent(new ImagePreviewToolbarRequestEventArgs(ToolbarSource)
+        {
+            RoutedEvent = routedEvent
+        });
     }
 }

--- a/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewToolbar.cs
+++ b/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewToolbar.cs
@@ -4,6 +4,8 @@ namespace AtomUI.Desktop.Controls;
 
 internal class ImagePreviewToolbar : ImagePreviewBaseToolbar
 {
+    protected override ImagePreviewToolbarSource ToolbarSource => ImagePreviewToolbarSource.TitleBar;
+
     #region 内部属性定义
 
     internal static readonly DirectProperty<ImagePreviewToolbar, bool> IsLastImageProperty =

--- a/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewerDialog.cs
+++ b/src/AtomUI.Desktop.Controls/ImagePreviewer/ImagePreviewerDialog.cs
@@ -7,6 +7,8 @@ using AtomUI.Desktop.Controls.Themes;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.Utilities;
@@ -20,6 +22,33 @@ internal class ImagePreviewerDialog : Window,
                                       IMotionAwareControl,
                                       IManagedDialogPositionerDialog
 {
+    private enum ImageTransformRetentionMode
+    {
+        Reset,
+        Retain
+    }
+
+    private struct ImageSwitchTransformPolicy
+    {
+        public ImageTransformRetentionMode RetentionMode;
+        public bool SuppressResetAnimation;
+        public double RetainedScaleX;
+        public double RetainedScaleY;
+        public double RetainedRotate;
+
+        public static ImageSwitchTransformPolicy CreateDefault()
+        {
+            return new ImageSwitchTransformPolicy
+            {
+                RetentionMode = ImageTransformRetentionMode.Reset,
+                SuppressResetAnimation = false,
+                RetainedScaleX = 1.0,
+                RetainedScaleY = 1.0,
+                RetainedRotate = 0.0
+            };
+        }
+    }
+
     #region 公共属性定义
     public static readonly StyledProperty<IList<PreviewImageSource>?> SourcesProperty =
         AvaloniaProperty.Register<ImagePreviewerDialog, IList<PreviewImageSource>?>(nameof(Sources));
@@ -206,6 +235,12 @@ internal class ImagePreviewerDialog : Window,
             nameof(IsImageFitToWindow),
             o => o.IsImageFitToWindow,
             (o, v) => o.IsImageFitToWindow = v);
+
+    internal static readonly DirectProperty<ImagePreviewerDialog, bool> SuppressTransformAnimationProperty =
+        AvaloniaProperty.RegisterDirect<ImagePreviewerDialog, bool>(
+            nameof(SuppressTransformAnimation),
+            o => o.SuppressTransformAnimation,
+            (o, v) => o.SuppressTransformAnimation = v);
     
     private PreviewImageSource? _currentImage;
 
@@ -294,6 +329,14 @@ internal class ImagePreviewerDialog : Window,
         get => _isImageFitToWindow;
         set => SetAndRaise(IsImageFitToWindowProperty, ref _isImageFitToWindow, value);
     }
+
+    private bool _suppressTransformAnimation;
+
+    internal bool SuppressTransformAnimation
+    {
+        get => _suppressTransformAnimation;
+        set => SetAndRaise(SuppressTransformAnimationProperty, ref _suppressTransformAnimation, value);
+    }
     
     #endregion
     
@@ -304,30 +347,32 @@ internal class ImagePreviewerDialog : Window,
     private bool _needsUpdate;
     private readonly ManagedDialogPositioner _positioner;
     private AbstractImagePreviewer _imagePreviewer;
+    private ImageViewer? _imageViewer;
     private PixelPoint _latestDialogPosition;
     private bool _firstSizeCalculated;
+    private ImageSwitchTransformPolicy _switchTransformPolicy = ImageSwitchTransformPolicy.CreateDefault();
 
     static ImagePreviewerDialog()
     {
         AffectsRender<ImagePreviewerDialog>(CurrentImageProperty);
         ImagePreviewBaseToolbar.HorizontalFlipRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleHorizontalFlipRequest();
+            dialog.HandleHorizontalFlipRequest(args);
             args.Handled = true;
         });
         ImagePreviewBaseToolbar.VerticalFlipRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleVerticalFlipRequest();
+            dialog.HandleVerticalFlipRequest(args);
             args.Handled = true;
         });
         ImagePreviewBaseToolbar.RotateLeftRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleRotateLeftRequest();
+            dialog.HandleRotateLeftRequest(args);
             args.Handled = true;
         });
         ImagePreviewBaseToolbar.RotateRightRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleRotateRightRequest();
+            dialog.HandleRotateRightRequest(args);
             args.Handled = true;
         });
         ImagePreviewBaseToolbar.ScaleDownRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
@@ -347,22 +392,34 @@ internal class ImagePreviewerDialog : Window,
         });
         ImagePreviewBaseToolbar.PreviousRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandlePreviousRequest();
+            dialog.HandlePreviousRequest(useTransformPolicy: true);
             args.Handled = true;
         });
         ImagePreviewBaseToolbar.NextRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleNextImageRequest();
+            dialog.HandleNextImageRequest(useTransformPolicy: true);
             args.Handled = true;
         });
         ImageViewer.PreviousRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandlePreviousRequest();
+            dialog.HandlePreviousRequest(useTransformPolicy: true);
             args.Handled = true;
         });
         ImageViewer.NextRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
         {
-            dialog.HandleNextImageRequest();
+            dialog.HandleNextImageRequest(useTransformPolicy: true);
+            args.Handled = true;
+        });
+        ImageViewer.ScaleDownRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
+        {
+            var viewer = args.Source as ImageViewer;
+            dialog.HandleScaleDownRequest(viewer?.WheelScaleStep);
+            args.Handled = true;
+        });
+        ImageViewer.ScaleUpRequestEvent.AddClassHandler<ImagePreviewerDialog>((dialog, args) =>
+        {
+            var viewer = args.Source as ImageViewer;
+            dialog.HandleScaleUpRequest(viewer?.WheelScaleStep);
             args.Handled = true;
         });
     }
@@ -372,6 +429,7 @@ internal class ImagePreviewerDialog : Window,
         ParentTopLevel  = parent;
         _positioner     = new ManagedDialogPositioner(this);
         _imagePreviewer = imagePreviewer;
+        AddHandler(KeyDownEvent, HandleDialogKeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
 #if DEBUG
         this.AttachDevTools();
 #endif
@@ -527,6 +585,7 @@ internal class ImagePreviewerDialog : Window,
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
+        _imageViewer = e.NameScope.Find<ImageViewer>(ImagePreviewerThemeConstants.ImageViewerPart);
         HandleCurrentIndexChanged();
     }
 
@@ -550,30 +609,73 @@ internal class ImagePreviewerDialog : Window,
         return ClientSize;
     }
     
-    private void HandleHorizontalFlipRequest()
+    private void UpdateSwitchTransformPolicy(ImagePreviewToolbarSource source)
     {
+        if (source == ImagePreviewToolbarSource.TitleBar)
+        {
+            _switchTransformPolicy.RetentionMode = ImageTransformRetentionMode.Retain;
+            _switchTransformPolicy.SuppressResetAnimation = false;
+            return;
+        }
+
+        _switchTransformPolicy.RetentionMode = ImageTransformRetentionMode.Reset;
+        _switchTransformPolicy.SuppressResetAnimation = true;
+    }
+
+    private void CaptureRetainedFlipRotateState()
+    {
+        _switchTransformPolicy.RetainedScaleX = ImageScaleX > 0.0 ? 1.0 : -1.0;
+        _switchTransformPolicy.RetainedScaleY = ImageScaleY > 0.0 ? 1.0 : -1.0;
+        _switchTransformPolicy.RetainedRotate = ImageRotate;
+    }
+
+    private bool ShouldRetainFlipRotateOnSwitch => _switchTransformPolicy.RetentionMode == ImageTransformRetentionMode.Retain;
+
+    private void HandleHorizontalFlipRequest(ImagePreviewToolbarRequestEventArgs args)
+    {
+        UpdateSwitchTransformPolicy(args.ToolbarSource);
         SetCurrentValue(ImageScaleXProperty, -1 * ImageScaleX);
+        if (ShouldRetainFlipRotateOnSwitch)
+        {
+            CaptureRetainedFlipRotateState();
+        }
     }
     
-    private void HandleVerticalFlipRequest()
+    private void HandleVerticalFlipRequest(ImagePreviewToolbarRequestEventArgs args)
     {
+        UpdateSwitchTransformPolicy(args.ToolbarSource);
         SetCurrentValue(ImageScaleYProperty, -1 * ImageScaleY);
+        if (ShouldRetainFlipRotateOnSwitch)
+        {
+            CaptureRetainedFlipRotateState();
+        }
     }
     
-    private void HandleRotateLeftRequest()
+    private void HandleRotateLeftRequest(ImagePreviewToolbarRequestEventArgs args)
     {
+        UpdateSwitchTransformPolicy(args.ToolbarSource);
         SetCurrentValue(ImageRotateProperty, ImageRotate - MathUtilities.Deg2Rad(90));
+        if (ShouldRetainFlipRotateOnSwitch)
+        {
+            CaptureRetainedFlipRotateState();
+        }
     }
     
-    private void HandleRotateRightRequest()
+    private void HandleRotateRightRequest(ImagePreviewToolbarRequestEventArgs args)
     {
+        UpdateSwitchTransformPolicy(args.ToolbarSource);
         SetCurrentValue(ImageRotateProperty, ImageRotate + MathUtilities.Deg2Rad(90));
+        if (ShouldRetainFlipRotateOnSwitch)
+        {
+            CaptureRetainedFlipRotateState();
+        }
     }
     
-    private void HandleScaleDownRequest()
+    private void HandleScaleDownRequest(double? scaleStep = null)
     {
-        var scaleX = ImageScaleX * (1 / (1 + ScaleStep));
-        var scaleY = ImageScaleY * (1 / (1 + ScaleStep));
+        var step = ResolveScaleStep(scaleStep);
+        var scaleX = ImageScaleX * (1 / (1 + step));
+        var scaleY = ImageScaleY * (1 / (1 + step));
         if (MathUtilities.LessThan(Math.Abs(scaleX), MinScale))
         {
             if (scaleX > 0)
@@ -601,10 +703,11 @@ internal class ImagePreviewerDialog : Window,
         SetCurrentValue(ImageScaleChangedProperty, true);
     }
     
-    private void HandleScaleUpRequest()
+    private void HandleScaleUpRequest(double? scaleStep = null)
     {
-        var scaleX = ImageScaleX * (1 + ScaleStep);
-        var scaleY = ImageScaleY * (1 + ScaleStep);
+        var step = ResolveScaleStep(scaleStep);
+        var scaleX = ImageScaleX * (1 + step);
+        var scaleY = ImageScaleY * (1 + step);
 
         if (MathUtilities.GreaterThan(Math.Abs(scaleX), MaxScale))
         {
@@ -633,6 +736,48 @@ internal class ImagePreviewerDialog : Window,
         SetCurrentValue(ImageScaleChangedProperty, true);
     }
 
+    private double ResolveScaleStep(double? scaleStep)
+    {
+        var step = scaleStep ?? ScaleStep;
+        return MathUtilities.LessThanOrClose(step, 0.0) ? 0.1 : step;
+    }
+
+    private void HandleImageSwitchKeyDown(KeyEventArgs e)
+    {
+        var imageCount = Sources?.Count ?? Count;
+        if (imageCount <= 1)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Right)
+        {
+            e.Handled = true;
+            if (CurrentIndex < imageCount - 1)
+            {
+                HandleNextImageRequest(useTransformPolicy: true);
+            }
+        }
+        else if (e.Key == Key.Left)
+        {
+            e.Handled = true;
+            if (CurrentIndex > 0)
+            {
+                HandlePreviousRequest(useTransformPolicy: true);
+            }
+        }
+    }
+
+    private void HandleDialogKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Handled)
+        {
+            return;
+        }
+
+        HandleImageSwitchKeyDown(e);
+    }
+
     private void HandleFitToWindowRequest(bool isFitToWindow)
     {
         SetCurrentValue(ImageScaleXProperty, ImageScaleX > 0.0 ? 1.0 : -1.0);
@@ -640,23 +785,81 @@ internal class ImagePreviewerDialog : Window,
         SetCurrentValue(ImageScaleChangedProperty, false);
         SetCurrentValue(IsImageFitToWindowProperty, isFitToWindow);
     }
-    
-    private void HandleNextImageRequest()
+
+    private void EnsureDialogKeyboardFocus()
     {
-        SetCurrentValue(IsImageFitToWindowProperty, true);
-        SetCurrentValue(ImageScaleChangedProperty, false);
-        SetCurrentValue(ImageScaleXProperty, 1.0);
-        SetCurrentValue(ImageScaleYProperty, 1.0);
-        SetCurrentValue(CurrentIndexProperty, Math.Min(CurrentIndex + 1, Count - 1));
+        if (_imageViewer?.Focus() != true)
+        {
+            Focus();
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_imageViewer?.Focus() == true)
+            {
+                return;
+            }
+            
+            Focus();
+        }, DispatcherPriority.Background);
     }
     
-    private void HandlePreviousRequest()
+    private void ResetImageStateBeforeSwitch(bool useTransformPolicy)
     {
         SetCurrentValue(IsImageFitToWindowProperty, true);
         SetCurrentValue(ImageScaleChangedProperty, false);
+
+        if (useTransformPolicy && ShouldRetainFlipRotateOnSwitch)
+        {
+            SetCurrentValue(ImageScaleXProperty, _switchTransformPolicy.RetainedScaleX);
+            SetCurrentValue(ImageScaleYProperty, _switchTransformPolicy.RetainedScaleY);
+            SetCurrentValue(ImageRotateProperty, _switchTransformPolicy.RetainedRotate);
+            return;
+        }
+
         SetCurrentValue(ImageScaleXProperty, 1.0);
         SetCurrentValue(ImageScaleYProperty, 1.0);
-        SetCurrentValue(CurrentIndexProperty, Math.Max(CurrentIndex - 1, 0));
+        if (useTransformPolicy)
+        {
+            SetCurrentValue(ImageRotateProperty, 0.0);
+        }
+    }
+
+    private void SwitchImage(int offset, bool useTransformPolicy)
+    {
+        if (Count <= 0 || offset == 0)
+        {
+            return;
+        }
+
+        var suppressTransformAnimation = useTransformPolicy && _switchTransformPolicy.SuppressResetAnimation;
+        if (suppressTransformAnimation)
+        {
+            SetCurrentValue(SuppressTransformAnimationProperty, true);
+        }
+
+        ResetImageStateBeforeSwitch(useTransformPolicy);
+        var targetIndex = offset > 0
+            ? Math.Min(CurrentIndex + offset, Count - 1)
+            : Math.Max(CurrentIndex + offset, 0);
+        SetCurrentValue(CurrentIndexProperty, targetIndex);
+
+        if (suppressTransformAnimation)
+        {
+            SetCurrentValue(SuppressTransformAnimationProperty, false);
+        }
+
+        EnsureDialogKeyboardFocus();
+    }
+
+    private void HandleNextImageRequest(bool useTransformPolicy = false)
+    {
+        SwitchImage(1, useTransformPolicy);
+    }
+    
+    private void HandlePreviousRequest(bool useTransformPolicy = false)
+    {
+        SwitchImage(-1, useTransformPolicy);
     }
     
     protected override WindowTitleBar? NotifyCreateTitleBar(WindowTitleBar? oldTitleBar, CompositeDisposable disposables)

--- a/src/AtomUI.Desktop.Controls/ImagePreviewer/ImageViewer.cs
+++ b/src/AtomUI.Desktop.Controls/ImagePreviewer/ImageViewer.cs
@@ -82,6 +82,12 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
     public static RoutedEvent<RoutedEventArgs> NextRequestEvent =
         RoutedEvent.Register<ImageViewer, RoutedEventArgs>(nameof(NextRequest), RoutingStrategies.Bubble);
     
+    public static RoutedEvent<RoutedEventArgs> ScaleUpRequestEvent =
+        RoutedEvent.Register<ImageViewer, RoutedEventArgs>(nameof(ScaleUpRequest), RoutingStrategies.Bubble);
+    
+    public static RoutedEvent<RoutedEventArgs> ScaleDownRequestEvent =
+        RoutedEvent.Register<ImageViewer, RoutedEventArgs>(nameof(ScaleDownRequest), RoutingStrategies.Bubble);
+    
     public event EventHandler<RoutedEventArgs>? PreviousRequest
     {
         add => AddHandler(PreviousRequestEvent, value);
@@ -92,6 +98,18 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
     {
         add => AddHandler(NextRequestEvent, value);
         remove => RemoveHandler(NextRequestEvent, value);
+    }
+    
+    public event EventHandler<RoutedEventArgs>? ScaleUpRequest
+    {
+        add => AddHandler(ScaleUpRequestEvent, value);
+        remove => RemoveHandler(ScaleUpRequestEvent, value);
+    }
+    
+    public event EventHandler<RoutedEventArgs>? ScaleDownRequest
+    {
+        add => AddHandler(ScaleDownRequestEvent, value);
+        remove => RemoveHandler(ScaleDownRequestEvent, value);
     }
     
     #endregion
@@ -171,6 +189,12 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
             nameof(IsImageFitToWindow),
             o => o.IsImageFitToWindow,
             (o, v) => o.IsImageFitToWindow = v);
+
+    internal static readonly DirectProperty<ImageViewer, bool> SuppressTransformAnimationProperty =
+        AvaloniaProperty.RegisterDirect<ImageViewer, bool>(
+            nameof(SuppressTransformAnimation),
+            o => o.SuppressTransformAnimation,
+            (o, v) => o.SuppressTransformAnimation = v);
     
     private PreviewImageSource? _currentImage;
 
@@ -273,6 +297,14 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
         get => _isImageFitToWindow;
         set => SetAndRaise(IsImageFitToWindowProperty, ref _isImageFitToWindow, value);
     }
+
+    private bool _suppressTransformAnimation;
+
+    internal bool SuppressTransformAnimation
+    {
+        get => _suppressTransformAnimation;
+        set => SetAndRaise(SuppressTransformAnimationProperty, ref _suppressTransformAnimation, value);
+    }
     
     #endregion
     
@@ -284,9 +316,17 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
     private Point _delta;
     private ImagePreviewNavButton? _previousButton;
     private ImagePreviewNavButton? _nextButton;
+    private double _wheelScaleStep = 0.1;
+
+    internal double WheelScaleStep
+    {
+        get => _wheelScaleStep;
+        private set => _wheelScaleStep = value;
+    }
     
     static ImageViewer()
     {
+        FocusableProperty.OverrideDefaultValue<ImageViewer>(true);
         AffectsArrange<ImageViewer>(ImageTranslateXProperty, ImageTranslateYProperty, CurrentIndexProperty);
     }
 
@@ -317,6 +357,8 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
         {
             RaiseEvent(new RoutedEventArgs(NextRequestEvent));
         }
+
+        Focus();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -325,7 +367,8 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
         
         if (IsLoaded)
         {
-            if (change.Property == IsMotionEnabledProperty)
+            if (change.Property == IsMotionEnabledProperty ||
+                change.Property == SuppressTransformAnimationProperty)
             {
                 ConfigureTransitions(true);
             }
@@ -406,6 +449,12 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
     
     private void ConfigureTransitions(bool force)
     {
+        if (SuppressTransformAnimation)
+        {
+            Transitions = null;
+            return;
+        }
+
         if (IsMotionEnabled)
         {
             if (force || Transitions == null)
@@ -453,6 +502,35 @@ internal class ImageViewer : TemplatedControl, IMotionAwareControl
                 HandleDragging(e.GetPosition(this), delta);
             }
         }
+    }
+    
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+        
+        if (_image == null || MathUtilities.AreClose(e.Delta.Y, 0.0))
+        {
+            return;
+        }
+        
+        // Map wheel delta to dynamic zoom step: touchpad tiny deltas become smooth small steps.
+        WheelScaleStep = Math.Clamp(Math.Abs(e.Delta.Y) * 0.08, 0.005, 0.12);
+        if (e.Delta.Y > 0.0)
+        {
+            if (IsScaleUpEnabled)
+            {
+                RaiseEvent(new RoutedEventArgs(ScaleUpRequestEvent));
+            }
+        }
+        else
+        {
+            if (IsScaleDownEnabled)
+            {
+                RaiseEvent(new RoutedEventArgs(ScaleDownRequestEvent));
+            }
+        }
+
+        e.Handled = true;
     }
     
     private void HandleDragging(Point position, Point delta)

--- a/src/AtomUI.Desktop.Controls/ImagePreviewer/Themes/ImagePreviewerDialogTheme.axaml
+++ b/src/AtomUI.Desktop.Controls/ImagePreviewer/Themes/ImagePreviewerDialogTheme.axaml
@@ -68,6 +68,7 @@
                                                         ImageRotate="{TemplateBinding ImageRotate}"
                                                         IsImageMovable="{TemplateBinding IsImageMovable}"
                                                         IsImageFitToWindow="{TemplateBinding IsImageFitToWindow}"
+                                                        SuppressTransformAnimation="{TemplateBinding SuppressTransformAnimation}"
                                                         ImageScaleChanged="{TemplateBinding ImageScaleChanged}" />
                                                 </Border>
                                             </Panel>


### PR DESCRIPTION
close #208 

新增以下特性

- 标题栏工具栏执行翻转/旋转后，切换图片时保留这些状态（键盘与图片内切换按钮一致）
- 图片内工具栏执行翻转/旋转后，切换图片时不保留状态，始终按图片原始状态展示
- 统一键盘切换、标题栏上一张/下一张、图片内上一张/下一张的行为规则